### PR TITLE
DO-286 Migrate Claude review workflow to quantivly/ci

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,5 +22,5 @@ jobs:
       contains(github.event.comment.body, '@claude')
 
     # Call the centralized reusable workflow from the .github organization repository
-    uses: quantivly/.github/.github/workflows/claude-review.yml@master
+    uses: quantivly/ci/.github/workflows/claude-review.yml@master
     secrets: inherit  # Pass all organization secrets to the reusable workflow


### PR DESCRIPTION
## Summary
- Migrate Claude review caller workflow reference from public `quantivly/.github` to private `quantivly/ci`

## Context
The review system (workflow, prompts, standards) has been moved to a private repo to keep proprietary CI tooling out of the public `.github` repo.

This is a one-line change to the `uses:` reference.

## Test plan
- [ ] Verify workflow triggers on `@claude` comment after merge

Generated with [Claude Code](https://claude.com/claude-code)